### PR TITLE
Fix the bug in read_json_field function

### DIFF
--- a/recipes/distilqwen_series/distillqwen2/dpo_student_infer_only.py
+++ b/recipes/distilqwen_series/distillqwen2/dpo_student_infer_only.py
@@ -32,9 +32,7 @@ def read_json_field(filename):
             data = json.load(file)
         output = []
         for item in data:
-            instruction = item["instruction"]
-            output = item["output"]
-            output.append({"prompt": instruction, "chosen": output})
+            output.append({"prompt": item["instruction"], "chosen": item["output"]})
         return output
     except FileNotFoundError:
         logging.error("The file was not found.")


### PR DESCRIPTION
There is a bug here where the 'output' variable is wrongly overwritten within the for loop, resulting in incorrect data being read at the end. My pull request is precisely aimed at fixing this issue.